### PR TITLE
Updating stepper pulse width for compatibility with newer high current stepper drivers.

### DIFF
--- a/firmware/AdvancedFirmata/FirmataStepper.cpp
+++ b/firmware/AdvancedFirmata/FirmataStepper.cpp
@@ -336,11 +336,11 @@ void FirmataStepper::updateStepPosition() {
 void FirmataStepper::stepMotor(byte step_num, byte direction) {
   if (this->interface == FirmataStepper::DRIVER) {
     digitalWrite(dir_pin, direction);
-      // delayMicroseconds(2); Provides compatibility with some high current stepper drivers (e.g. TI DRV8825)
-      delayMicroseconds(1);
+      delayMicroseconds(2);
+      // delayMicroseconds(1); // For improved speed on an EasyDriver, change the step speed to 1us
       digitalWrite(step_pin, LOW);
-      // delayMicroseconds(2); Provides compatibility with some high current stepper drivers (e.g. TI DRV8825)
-      delayMicroseconds(1);
+      // delayMicroseconds(1);
+      delayMicroseconds(2);
       digitalWrite(step_pin, HIGH);
   } else if (this->interface == FirmataStepper::TWO_WIRE) {
     switch (step_num) {


### PR DESCRIPTION
Figured I'd add comments about how to make this code compatible with the DRV8825. Should save someone a bit of time figuring out why steps are being skipped. I have tested this and it works smoothly.

For anyone having trouble getting high current stepper motors to work in the future: MAKE SURE YOU READ THE SPEC SHEET. That is all.

Note: This will affect the BreakoutJS web interface acceleration/speed calculation.
